### PR TITLE
Issue 7269 diagnostic printer

### DIFF
--- a/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
+++ b/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java
@@ -9,6 +9,7 @@ import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.os.IsDefined;
 import com.oracle.svm.core.posix.headers.Pthread;
 
 /**
@@ -43,7 +44,7 @@ public final class DiagnosticPrinter {
             w.print("prio=");
             w.print(thread.getPriority());
             w.print(" tid=");
-            if (Target_PosixJavaThreads.hasThreadIdentifier(thread)) {
+            if ((IsDefined.isLinux() || IsDefined.isDarwin()) && Target_PosixJavaThreads.hasThreadIdentifier(thread)) {
                 final long nativeId = Target_PosixJavaThreads.getPthreadIdentifier(thread).rawValue();
                 w.print("0x");
                 w.println(Long.toHexString(nativeId));


### PR DESCRIPTION
This PR fixes the following issue that happens while running Quarkus with GraalVM `20.0.0` on Windows:

```
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: type is not available in this platform: io.quarkus.runtime.graal.DiagnosticPrinter$Target_PosixJavaThreads
Trace:
        at parsing io.quarkus.runtime.graal.DiagnosticPrinter.printDiagnostics(DiagnosticPrinter.java:46)
Call path from entry point to io.quarkus.runtime.graal.DiagnosticPrinter.printDiagnostics(PrintStream):
        at io.quarkus.runtime.graal.DiagnosticPrinter.printDiagnostics(DiagnosticPrinter.java:29)
        at io.quarkus.runtime.Application$2.handle(Application.java:209)
        at sun.misc.Signal$InternalMiscHandler.handle(Signal.java:198)
        at jdk.internal.misc.Signal$1.run(Signal.java:220)
        at java.lang.Thread.run(Thread.java:834)
        at com.oracle.svm.core.thread.JavaThreads.threadStartRoutine(JavaThreads.java:527)
        at com.oracle.svm.core.windows.WindowsJavaThreads.osThreadStartRoutine(WindowsJavaThreads.java:138)
        at com.oracle.svm.core.code.IsolateEnterStub.WindowsJavaThreads_osThreadStartRoutine_4bc03aa26f8cdfc97ebd54050e8ae4bce1023851(generated:0)
```

This error was caused by the following Quarkus code:

https://github.com/quarkusio/quarkus/blob/3fbdbc399f4c274054bed23d70061c028e7a59c7/core/runtime/src/main/java/io/quarkus/runtime/graal/DiagnosticPrinter.java#L46-L50