### PR TITLE
Mention GraalVM 20.0.0 in the exception message of the version check

### DIFF
--- a/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkus/deployment/pkg/steps/NativeImageBuildStep.java
@@ -374,8 +374,8 @@ public class NativeImageBuildStep {
         final List<String> obsoleteGraalVmVersions = Arrays.asList("1.0.0", "19.0.", "19.1.", "19.2.", "19.3.0");
         final boolean vmVersionIsObsolete = obsoleteGraalVmVersions.stream().anyMatch(v -> version.contains(" " + v));
         if (vmVersionIsObsolete) {
-            throw new IllegalStateException(
-                    "Out of date version of GraalVM detected: " + version + ". Please upgrade to GraalVM 19.3.1.");
+            throw new IllegalStateException("Out of date version of GraalVM detected: " + version + "."
+                    + " Quarkus currently supports GraalVM 19.3.1 and 20.0.0. Please upgrade GraalVM to one of these versions.");
         }
     }
 


### PR DESCRIPTION
@gsmet Je pose la question dans mon fork pour éviter de polluer le repo Quarkus :) En supposant que l'annonce du support en preview de GraalVM 20 soit prévu dans la 1.3, est-ce que tu veux que je fasse cette PR dans Quarkus `master` ?